### PR TITLE
Genericize db info and add setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,29 @@ You will need [Leiningen][1] 2.0 or above installed.
 
 [1]: https://github.com/technomancy/leiningen
 
+### Getting up and running in Debian (wheezy)
+
+Most necessary packages are out of date in `wheezy` but may be updated in newer
+distributions.  Most of this section applies to apt-based systems.  Just be sure
+to check your package versions.
+
+First install OpenJDK 7 and Postgres 9.1:
+
+`sudo apt-get install openjdk-7-jdk postgresql-9.1`
+
+Once that's all set, set OpenJDK 7 as your default JVM:
+
+`sudo update-alternatives --config java`
+
+Then create your database:
+
+`sudo -u postgres psql`
+`CREATE DATABASE madetomeasure_development;`
+`CREATE USER dev WITH PASSWORD madetomeasure;`
+`GRANT ALL PRIVILEGES ON DATABASE madetomeasure_development TO dev;`
+
+Finally, run your migrations and tests.
+
 ## Running
 
 To start a web server for the application, run:
@@ -12,7 +35,7 @@ To start a web server for the application, run:
 
 ## Migrations
 
-We use ragtime to handle migrations and instead of active record style migrations it utilizes SQL.
+We use clj-sql-up to handle migrations and instead of active record style migrations it utilizes SQL.
 
 The basic way they are written is: `./migrations/${date}_name_.up.sql` and `./migrations/${date}_name_.down.sql`
 
@@ -24,11 +47,16 @@ To make a new migration run `script/new_migration NAME_OF_MIGRATION_NO_SPACES`
 
 ### Migrating
 
-Migrating is simple as `lein ragtime migrate`
+Migrating is simple as `lein clj-sql-up migrate`
 
 ### Rollbacks
 
-Rollbacks are simple as `lein ragtime rollback`
+Rollbacks are simple as `lein clj-sql-up rollback`
+
+
+## Tests
+
+Run tests with `lein test`.
 
 ## Help
 

--- a/profiles.clj
+++ b/profiles.clj
@@ -1,2 +1,35 @@
-{:dev {:env {:database-url "jdbc:postgresql://localhost/madetomeasure_development?user=matthewkirk"}
-       :production {:env {:database-url "jdbc:postgresql://localhost/madetomeasure_development?user=matthewkirk"}}}}
+{
+ :dev {
+       :env {
+             :dev true
+             ; FIXME (cmhobbs) convert these to canonical JDBC connection strings in the
+             ;       following format:  jdbc:postgresql://username:password@hostname/dbname
+             :database-url "jdbc:postgresql://localhost/madetomeasure_development?user=dev&password=madetomeasure"             
+             }
+       :dependencies [[ring-mock "0.1.5"]
+                      [ring/ring-devel "1.3.2"]
+                      [pjstadig/humane-test-output "0.7.0"]
+                      ]
+       :source-paths ["env/dev/clj"]
+
+
+
+       :repl-options {:init-ns madetomeasure-api.repl}
+       :injections [(require 'pjstadig.humane-test-output)
+                    (pjstadig.humane-test-output/activate!)]
+       }
+ :production 
+ {
+  ; FIXME (cmhobbs) convert these to canonical JDBC connection strings in the
+  ;       following format:  jdbc:postgresql://username:password@hostname/dbname
+  :env {:database-url "jdbc:postgresql://localhost/madetomeasure?user=deploy"}
+  }
+ }
+
+{
+ :uberjar {
+           :omit-source true
+           :env {:production true}
+           :aot :all
+           }
+ }

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject madetomeasure-api "0.1.0-SNAPSHOT"
 
-            :description "FIXME: write description"
-            :url "http://example.com/FIXME"
+            :description "Made to Measure user-facing API"
+            :url "http://madetomeasure.io"
 
             :dependencies [[org.clojure/clojure "1.6.0"]
                            [ring-server "0.4.0"]
@@ -31,37 +31,19 @@
 
             :main madetomeasure-api.core
 
-            :plugins [[lein-ring "0.9.1"]
-                      [lein-environ "1.0.0"]
-                      [lein-ancient "0.6.5"]
-                      [clj-sql-up "0.3.7"]
-                      [lein-cljfmt "0.1.10"]]
+  :plugins [[lein-ring "0.9.1"]
+            [lein-environ "1.0.0"]
+            [lein-ancient "0.6.5"]
+            [clj-sql-up "0.3.7"]
+            [lein-cljfmt "0.1.10"]]
+  
+    :ring {:handler madetomeasure-api.handler/app
+         :init    madetomeasure-api.handler/init
+         :destroy madetomeasure-api.handler/destroy
+         :uberwar-name "madetomeasure-api.war"}
 
-
-            :ring {:handler madetomeasure-api.handler/app
-                   :init    madetomeasure-api.handler/init
-                   :destroy madetomeasure-api.handler/destroy
-                   :uberwar-name "madetomeasure-api.war"}
-
-            :clj-sql-up {:database "jdbc:postgresql://localhost/madetomeasure_development?user=matthewkirk"
-                         :database-test "jdbc:postgresql://localhost/madetomeasure_test?user=matthewkirk"
-                         :deps [[org.postgresql/postgresql "9.3-1102-jdbc41"]]}
-
-            :profiles
-            {:uberjar {:omit-source true
-                       :env {:production true}
-
-                       :aot :all}
-             :dev {:dependencies [[ring-mock "0.1.5"]
-                                  [ring/ring-devel "1.3.2"]
-                                  [pjstadig/humane-test-output "0.7.0"]
-                                  ]
-                   :source-paths ["env/dev/clj"]
-
-
-
-                   :repl-options {:init-ns madetomeasure-api.repl}
-                   :injections [(require 'pjstadig.humane-test-output)
-                                (pjstadig.humane-test-output/activate!)]
-                   :env {:dev true}}})
-
+  ; FIXME (cmhobbs) convert these to canonical JDBC connection strings in the
+  ;       following format:  jdbc:postgresql://username:password@hostname/dbname
+  :clj-sql-up {:database "jdbc:postgresql://localhost/madetomeasure_development?user=dev&password=madetomeasure"
+              :database-test "jdbc:postgresql://localhost/madetomeasure_test?user=dev&password=madetomeasure"
+              :deps [[org.postgresql/postgresql "9.3-1102-jdbc41"]]})

--- a/src/madetomeasure_api/db/core.clj
+++ b/src/madetomeasure_api/db/core.clj
@@ -4,14 +4,16 @@
     [clojure.string :as str]
     [environ.core :refer [env]]))
 
-
+; NOTE (cmhobbs) this function takes in a postgres adaptor URI in the
+;      form of:  jdbc:postgresql://hostname/dbname?user=username&password=pass
+;      and maps it to the standard format documented here:
+;      http://clojure-doc.org/articles/ecosystem/java_jdbc/home.html#setting-up-a-data-source
+;
+; FIXME (cmhobbs) cause this function to consume and return a canonical
+;       JDBC connection string in the form of:
+;       jdbc:postgresql://username:password@hostname/dbname 
 (def db-spec
-  "For some reason jdbc doesn't have a function to parse this url type
-  So this takes the databse-url and returns a given map that can be used
-  by Yesql:
-  JDBC takes the form of jdbc:vendor//host/dbname?user=name"
-  (let [connection-url (or (System/getenv "DATABASE_URL")
-                           (env :database-url))
+  (let [connection-url (env :database-url)
         parts (str/split connection-url #":")
         subprotocol (nth parts 1)
         subname (nth parts 2)]

--- a/test/madetomeasure_api/test/routes/subscribers.clj
+++ b/test/madetomeasure_api/test/routes/subscribers.clj
@@ -7,8 +7,9 @@
         madetomeasure-api.handler))
 
 (def subscriber
+;  (first (clojure.java.jdbc/insert! db/db-spec :subscribers {:address "zlap@flap.com"})))
   (first (clojure.java.jdbc/insert! db/db-spec :subscribers {:address "zlap@flap.com"})))
-
+  
 (deftest subscribers
          (testing "creation"
                   (let [subscribers '({:address "flap@flap.com"} {:address "flap@gums.com"})


### PR DESCRIPTION
Rather than clean up connections, this commit opts for commenting
to identify points to refactor.
